### PR TITLE
Fix uploading jars to maven central

### DIFF
--- a/java/Makefile.am
+++ b/java/Makefile.am
@@ -57,8 +57,8 @@ check-local:
 publishToMavenLocal:
 	$(srcdir)/gradlew publishToMavenLocal
 
-bintrayUpload:
-	$(srcdir)/gradlew bintrayUpload
+publish:
+	$(srcdir)/gradlew publish
 
 endif
 

--- a/java/build.gradle.in
+++ b/java/build.gradle.in
@@ -9,16 +9,13 @@ buildscript {
 }
 
 plugins {
+    id 'java-library'
     id 'com.adarshr.test-logger' version '1.7.0'
     id 'maven-publish'
-
-    id 'com.jfrog.bintray' version '1.8.4'
+    id 'signing'
 }
 
-apply plugin: 'java'
-apply plugin: 'java-library'
 apply plugin: 'biz.aQute.bnd.builder'
-
 
 version = '4.0.0'
 group = 'com.github.tschoonj'
@@ -136,22 +133,18 @@ publishing {
             }
         }
     }
-}
-
-bintray {
-    user = 'tschoonj'
-    key = System.getenv('BINTRAY_KEY')
-    pkg {
-        repo = 'maven'
-        name = 'xraylib'
-        userOrg = 'tschoonj'
-        licenses = ['BSD 3-Clause']
-        vcsUrl = 'https://github.com/tschoonj/xraylib.git'
-        version {
-            name = project.version
-            released  = new Date()
+    repositories {
+        maven {
+            name = 'Sonatype'
+            url "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+            credentials {
+                username System.getenv('SONATYPE_USERNAME')
+                password System.getenv('SONATYPE_PASSWORD')
+            }
         }
     }
-    // Upload the 'maven' publication i.e jar, sourcesJar, javadocJar, POM
-    publications = ['maven']
+}
+
+signing {
+    sign publishing.publications.maven
 }

--- a/java/build.gradle.in
+++ b/java/build.gradle.in
@@ -2,20 +2,15 @@ buildscript {
     repositories {
         mavenCentral()
     }
-
-    dependencies {
-        classpath 'biz.aQute.bnd:biz.aQute.bnd.gradle:4.2.0'
-    }
 }
 
 plugins {
-    id 'java-library'
-    id 'com.adarshr.test-logger' version '1.7.0'
-    id 'maven-publish'
-    id 'signing'
+    id "java-library"
+    id "com.adarshr.test-logger" version "2.1.1"
+    id "maven-publish"
+    id "signing"
+    id "biz.aQute.bnd.builder" version "5.3.0"
 }
-
-apply plugin: 'biz.aQute.bnd.builder'
 
 version = '4.0.0'
 group = 'com.github.tschoonj'
@@ -31,9 +26,9 @@ repositories {
 
 dependencies {
 	api 'org.apache.commons:commons-math3:3.6.1'
-	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.4.2'
-	testImplementation 'org.junit.jupiter:junit-jupiter-params:5.4.2'
-	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.4.2'
+	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.1'
+	testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.1'
+	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.1'
 }
 
 sourceSets {

--- a/java/gradle/wrapper/gradle-wrapper.properties
+++ b/java/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Fixes #149
Update gradle to 6.8.3
Uploading itself remains untested, GPG signing works though.