### PR TITLE
meson: remove cython option

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,4 +3,3 @@ option('python-bindings', type: 'feature', value: 'auto', description: 'Build cl
 option('python-numpy-bindings', type: 'feature', value: 'auto', description: 'Build numpy Python bindings')
 option('swig', type : 'string', value : 'swig', description: 'Path to swig executable')
 option('python', type : 'string', value : 'python3', description: 'Python interpreter to compile bindings for')
-option('cython', type : 'string', value : 'cython', description: 'Cython to use for generating C glue code')

--- a/python/meson.build
+++ b/python/meson.build
@@ -56,7 +56,7 @@ if not get_option('python-bindings').disabled()
 endif
 
 if not get_option('python-numpy-bindings').disabled()
-    cython = find_program(get_option('cython'), 'cython', 'cython3', 'cython-3', 'cython' + python.language_version(), 'cython-' + python.language_version(), required : false)
+    cython = find_program('cython', 'cython3', 'cython-3', 'cython' + python.language_version(), 'cython-' + python.language_version(), required : false)
     deps = [python_dep, xraylib_lib_dep]
     # lld-link doesnt find the openmp import libraries
     if cc.get_id() != 'clang-cl'


### PR DESCRIPTION
meson 0.59.0 introduces full support for cython, making it illegal to use `cython` as option.
Given that the PATH is already searched by `find_program` for all cython names I have ever come across, it doesn't seem very useful anyway.