### PR TITLE
Fix python bindings compilation with swig using meson

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,9 +85,9 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-    - uses: crazy-max/ghaction-chocolatey@v2.0.0
-      with:
-        args: install innosetup lazarus
+    # - uses: crazy-max/ghaction-chocolatey@v2.0.0
+    #   with:
+    #     args: install innosetup lazarus
     # required for the lib command
     - uses: ilammy/msvc-dev-cmd@v1.10.0
       with:
@@ -147,7 +147,7 @@ jobs:
         make check
         make distclean
 
-        ./configure --disable-python --disable-python-numpy --enable-fortran2003 --enable-pascal FPC=/c/lazarus/fpc/*/bin/x86_64-win64/fpc --disable-ruby
+        ./configure --disable-python --disable-python-numpy --enable-fortran2003 --disable-ruby
         make
         make check
         make distclean

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-    - uses: crazy-max/ghaction-chocolatey@v1.6.0
+    - uses: crazy-max/ghaction-chocolatey@v2.0.0
       with:
         args: install innosetup lazarus
     # required for the lib command

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
     name: Pip install with Python ${{ matrix.python-version }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -39,16 +39,10 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
         compiler:
           - cl
           - clang-cl
-        # don't know why but cl.exe does not like the Cython generated code with python < 3.8
-        include:
-          - numpy: enabled
-          - python-version: 3.7
-            numpy: disabled
-            compiler: cl
     name: Visual Studio with ${{matrix.compiler}} and Python ${{ matrix.python-version }}
     steps:
     - uses: actions/checkout@v3
@@ -63,10 +57,10 @@ jobs:
     - uses: ilammy/msvc-dev-cmd@v1.10.0
     - name: Build with meson
       run: |
-        meson setup builddir --buildtype=release -Dpython=python -Dpython-bindings=enabled -Dpython-numpy-bindings=${{ matrix.numpy }}
-        ninja -v -C builddir
-        ninja -v -C builddir test
-        # ninja -v -C builddir dist
+        meson setup meson-build --buildtype=release -Dpython=python -Dpython-bindings=enabled -Dpython-numpy-bindings=enabled
+        meson compile -C meson-build
+        meson test -C meson-build
+        # ninja -v -C meson-build dist
       env:
         CC: ${{ matrix.compiler }}
         CXX: ${{ matrix.compiler }}
@@ -128,35 +122,14 @@ jobs:
       if: matrix.buildsystem == 'meson'
       run: |
         set -ex
-
-        mkdir build
-        cd build
-        meson -Dpython-bindings=enabled -Dpython-numpy-bindings=enabled ..
-        ninja
-        ninja test
-        ninja dist
+        meson setup meson-build -Dpython-bindings=enabled -Dpython-numpy-bindings=enabled
+        meson compile -C meson-build
+        meson test -C meson-build
 
         set +ex
       env:
         CC: ${{matrix.cc}}
         CXX: ${{matrix.cxx}}
-    - name: Secondary build with Autotools 
-      if: matrix.buildsystem == 'meson'
-      run: |
-        set -ex
-        cd build/meson-dist/
-        TARBALL=$(ls *.tar.xz)
-        tar xfJ $TARBALL
-        cd ${TARBALL%.tar.xz}
-        autoreconf -fi
-        ./configure --enable-python --disable-ruby
-        make
-        set +ex
-      env:
-        CC: ${{matrix.cc}}
-        CXX: ${{matrix.cxx}}
-        CYTHON: cython
-        PYTHON: python3
     - name: Primary build and test with Autotools
       if: matrix.buildsystem == 'autotools'
       run: |
@@ -182,7 +155,6 @@ jobs:
         ./configure --enable-python --enable-python-numpy PYTHON=python3 --disable-ruby
         make
         make check
-        make dist
 
         set +ex
       env:
@@ -191,23 +163,6 @@ jobs:
         CYTHON: cython
         PYTHON: python3
     
-    - name: Secondary build with Meson
-      if: matrix.buildsystem == 'autotools'
-      run: |
-        set -ex
-        export PATH=${HOME}/.local/bin:${PATH}
-        TARBALL=$(ls *.tar.gz)
-        tar xfz $TARBALL
-        cd ${TARBALL%.tar.gz}
-        mkdir build-meson
-        cd build-meson
-        meson -Dpython-bindings=enabled -Dpython-numpy-bindings=enabled ..
-        ninja
-        set +ex
-      env:
-        CC: ${{matrix.cc}}
-        CXX: ${{matrix.cxx}}
-
   macos:
     timeout-minutes: 60
     runs-on: macos-latest
@@ -254,13 +209,10 @@ jobs:
       if: matrix.buildsystem == 'meson'
       run: |
         set -ex
-
-        mkdir build
-        cd build
-        meson -Dpython=/usr/local/bin/python3 -Dpython-bindings=enabled -Dpython-numpy-bindings=enabled ..
-        ninja
-        ninja test
-        ninja dist
+        meson setup meson-build -Dpython=/usr/local/bin/python3 -Dpython-bindings=enabled -Dpython-numpy-bindings=enabled
+        meson compile -C meson-build
+        meson test -C meson-build
+        meson dist -C meson-build
 
         set +ex
       env:
@@ -271,7 +223,7 @@ jobs:
       if: matrix.buildsystem == 'meson'
       run: |
         set -ex
-        cd build/meson-dist/
+        cd meson-build/meson-dist/
         TARBALL=$(ls *.tar.xz)
         tar xfJ $TARBALL
         cd ${TARBALL%.tar.xz}
@@ -332,10 +284,8 @@ jobs:
         TARBALL=$(ls *.tar.gz)
         tar xfz $TARBALL
         cd ${TARBALL%.tar.gz}
-        mkdir build-meson
-        cd build-meson
-        meson -Dpython-bindings=enabled -Dpython-numpy-bindings=enabled ..
-        ninja
+        meson setup meson-build -Dpython-bindings=enabled -Dpython-numpy-bindings=enabled
+        meson compile -C meson-build
         set +ex
       env:
         CC: ${{matrix.cc}}
@@ -499,12 +449,11 @@ jobs:
       if: matrix.buildsystem == 'meson'
       run: |
         set -ex
-        mkdir build
-        cd build
-        meson -Dpython-bindings=enabled -Dpython-numpy-bindings=enabled ..
-        ninja
-        ninja test
-        ninja dist
+        git config --global --add safe.directory /__w/xraylib/xraylib
+        meson setup meson-build -Dpython-bindings=enabled -Dpython-numpy-bindings=enabled
+        meson compile -C meson-build
+        meson test -C meson-build
+        meson dist -C meson-build
         set +ex
       env:
         CYTHON: ${{matrix.cython}}

--- a/python/meson.build
+++ b/python/meson.build
@@ -4,7 +4,7 @@ import numpy
 print(numpy.get_include())
 '''
 
-rv = run_command(get_option('python'), '-c', numpy_include_script,)
+rv = run_command(get_option('python'), '-c', numpy_include_script, check: false)
 if rv.returncode() != 0
   error('Could not retrieve numpy include location. Please check that numpy has been installed.')
 endif
@@ -33,6 +33,7 @@ if not get_option('python-bindings').disabled()
                 swig,
                 '-DVERSION=\'@0@\''.format(meson.project_version()),
                 '-includeall',
+                '-I@0@'.format(meson.current_source_dir()),
                 '-I@0@'.format(include_source_dir),
                 '-I@0@'.format(src_source_dir),
                 '-o', '@OUTPUT0@',

--- a/python/tests/Makefile.am
+++ b/python/tests/Makefile.am
@@ -15,6 +15,7 @@ dist_check_SCRIPTS = \
 	test-crystal_diffraction.py \
 	test-nist-compounds.py \
 	test-radionuclides.py \
+	test-numpy.py \
 	$(NULL)
 endif
 

--- a/python/tests/meson.build
+++ b/python/tests/meson.build
@@ -7,6 +7,7 @@ tests = [
 	'crystal_diffraction',
 	'nist-compounds',
 	'radionuclides',
+	'numpy',
 ]
 
 test_env = environment()

--- a/python/tests/test-numpy.py
+++ b/python/tests/test-numpy.py
@@ -1,0 +1,20 @@
+import unittest
+import xraylib
+import numpy as np
+
+class TestNumpy(unittest.TestCase):
+    def _test_np(self, dtype):
+        for Z in np.arange(10, 20, dtype=dtype):
+            print( xraylib.LineEnergy(Z, xraylib.KL2_LINE))
+
+    def test_np_i16(self):
+        self._test_np(np.int16)
+
+    def test_np_i32(self):
+        self._test_np(np.int32)
+
+    def test_np_i64(self):
+        self._test_np(np.int64)
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
This fixes #207 

Closes #201 
Closes #197 

Basically the meson build invocation of `swig` did not include the `pyfragments.swg` file, which is responsible for converting Numpy integers to C counterparts.

@ckoern