### PR TITLE
Fix python-numpy-bindings meson bug

### DIFF
--- a/python/meson.build
+++ b/python/meson.build
@@ -57,7 +57,7 @@ if not get_option('python-bindings').disabled()
 endif
 
 if not get_option('python-numpy-bindings').disabled()
-    cython = find_program('cython', 'cython3', 'cython-3', 'cython' + python.language_version(), 'cython-' + python.language_version(), required : false)
+    cython = find_program('cython', 'cython3', 'cython-3', 'cython' + python.language_version(), 'cython-' + python.language_version(), required : get_option('python-numpy-bindings'))
     deps = [python_dep, xraylib_lib_dep]
     # lld-link doesnt find the openmp import libraries
     if cc.get_id() != 'clang-cl'


### PR DESCRIPTION
This fix ensures that meson will error out when `python-numpy-bindings` is set to `enabled`, but `cython` is not found.