### PR TITLE
Release 4.2.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.2.0
+current_version = 4.2.1
 commit = True
 tag = False
 

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,8 @@
+Version 4.2.1 Tom Schoonjans
+
+- Fix Python bindings compilation with recent clang and swig
+- Build Python 3.10+ wheels only (drop Python 3.8 and 3.9 support). Now also add linux aarch64 wheel support
+
 Version 4.2.0 Tom Schoonjans
 
 - Java: update dependency from Commons Math3 to Commons Numbers Complex 1.2

--- a/configure.ac
+++ b/configure.ac
@@ -11,7 +11,7 @@
 
 
 
-AC_INIT([xraylib],[4.2.0],[Tom.Schoonjans@me.com])
+AC_INIT([xraylib],[4.2.1],[Tom.Schoonjans@me.com])
 AC_PREREQ([2.60])
 AC_CONFIG_SRCDIR([include/xraylib.h])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/idl/libxrlidl.dlm
+++ b/idl/libxrlidl.dlm
@@ -16,7 +16,7 @@ MODULE XRAYLIB
 
 DESCRIPTION IDL XRAYLIB BINDINGS
 
-VERSION 4.2.0
+VERSION 4.2.1
 
 SOURCE A.Brunetti, M. S. del Rio, T. Schoonjans, T. Ikonen, B. Golosio, A. Simionovici, A. Somogyi
 

--- a/include/xraylib.h
+++ b/include/xraylib.h
@@ -24,7 +24,7 @@ extern "C" {
 
 #define XRAYLIB_MAJOR 4
 #define XRAYLIB_MINOR 2
-#define XRAYLIB_MICRO 0
+#define XRAYLIB_MICRO 1
 
 
 #ifndef PI

--- a/java/build.gradle.in
+++ b/java/build.gradle.in
@@ -11,7 +11,7 @@ plugins {
     id "biz.aQute.bnd.builder" version "7.0.0"
 }
 
-version = '4.2.0'
+version = '4.2.1'
 group = 'com.github.tschoonj'
 sourceCompatibility = '1.8'
 targetCompatibility = '1.8'

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('xraylib',
     'c',
     meson_version: '>= 0.60.0',
-    version: '4.2.0',
+    version: '4.2.1',
     license: 'BSD',
     default_options: ['cpp_std=c++11',]
 )

--- a/pascal/xraylib.pas
+++ b/pascal/xraylib.pas
@@ -47,7 +47,7 @@ const
 // From xraylib.h
 const
   XRAYLIB_MAJOR = 4;
-  XRAYLIB_MINOR = 1;
+  XRAYLIB_MINOR = 2;
   XRAYLIB_MICRO = 1;
 
 procedure XRayInit;cdecl;external External_library name 'XRayInit';

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 dependencies = [
   "numpy"
 ]
-version = "4.2.0"
+version = "4.2.1"
 
 [project.urls]
 repository = "https://github.com/tschoonj/xraylib"

--- a/xraylib.spec
+++ b/xraylib.spec
@@ -18,7 +18,7 @@
 %define perl_vendor_autolib	%{perl_vendor_archlib}/auto
 
 Name: xraylib
-Version: 4.2.0
+Version: 4.2.1
 Release:	1%{?dist}
 Summary: A library for X-ray matter interactions cross sections for X-ray fluorescence applications: core C library
 Group:	 Applications/Engineering and Scientific	


### PR DESCRIPTION
Release version 4.2.1

### Changes
- Fix Python bindings compilation with recent clang and swig
- Update GitHub Actions dependencies:
  - Bump actions/checkout from 5 to 6
  - Bump github/codeql-action from 3.30.3 to 4.31.4
  - Bump pypa/cibuildwheel from 3.2.0 to 3.3.0
  - Bump actions/upload-artifact from 4 to 5
  - Bump actions/download-artifact from 5 to 6
- Build Python 3.10+ wheels only (drop Python 3.8 and 3.9 support)